### PR TITLE
Add documentation for "Note" type

### DIFF
--- a/src/note.rs
+++ b/src/note.rs
@@ -278,7 +278,6 @@ impl Note {
     ///     Note::new(Pitch::D_SHARP, 4),
     /// );
     ///
-    ///
     /// // Does nothing if a note with sharps is called with sharps
     /// assert_eq!(
     ///     Note::new(Pitch::C_SHARP, 4).respell_with(Spelling::Sharps),


### PR DESCRIPTION
Adds documentation for the `Note` type, its associated constants, and it's methods.

related: #2 