### PR TITLE
fix: Add missing hash derive for multiple types

### DIFF
--- a/src/harmony/key.rs
+++ b/src/harmony/key.rs
@@ -80,7 +80,7 @@ use std::str::FromStr;
 /// assert_eq!(c_minor, Key::minor(Pitch::C));
 /// assert_eq!(c_major.tonic, c_minor.tonic);
 /// ```
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Key {
     /// The tonic (root) pitch of the key.

--- a/src/harmony/mode.rs
+++ b/src/harmony/mode.rs
@@ -13,7 +13,7 @@ use std::str::FromStr;
 /// Intended to be used until a stable version on scales is released.
 ///
 /// [exp]: crate::scales::definition::heptatonic::DiatonicMode
-#[derive(Copy, Clone, Eq, PartialEq, Default, Debug, Ord, PartialOrd, strum_macros::FromRepr)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Default, Debug, Ord, PartialOrd, strum_macros::FromRepr)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DiatonicMode {
     #[default]

--- a/src/harmony/scale_degree.rs
+++ b/src/harmony/scale_degree.rs
@@ -9,7 +9,7 @@ use crate::scales::numeral::Numeral7 as ScaleDegreeExp;
 ///
 /// [exp]: crate::scales::numeral::Numeral7
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Default, Debug, Ord, PartialOrd, strum_macros::FromRepr)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Default, Debug, Ord, PartialOrd, strum_macros::FromRepr)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ScaleDegree {
     /// Scale degree I: The tonic.
@@ -64,7 +64,7 @@ impl ScaleDegree {
 }
 
 /// Error returned when parsing a [`ScaleDegree`] from [`&str`](prim@str) fails.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, thiserror::Error)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[error("The provided &str could not be converted into a ScaleDegree")]
 pub struct ParseScaleDegreeError;

--- a/src/notation/clef.rs
+++ b/src/notation/clef.rs
@@ -4,7 +4,7 @@ use std::ops::RangeInclusive;
 use crate::Letter;
 use crate::notation::{OctaveLetter, StemDirection, GetStemDirectionParams};
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PitchClef {
     // assuming there are only G, C, and F clefs

--- a/src/notation/octave_letter.rs
+++ b/src/notation/octave_letter.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 use std::fmt;
 use crate::{Note, Letter};
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OctaveLetter {
     pub letter: Letter,

--- a/src/notation/stem_direction.rs
+++ b/src/notation/stem_direction.rs
@@ -1,11 +1,11 @@
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum StemDirection {
     Up,
     Down,
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum GetStemDirectionParams {
     /// Only the first note and last note are considered (Default)

--- a/src/note.rs
+++ b/src/note.rs
@@ -53,7 +53,7 @@ use crate::pitch::Spelling;
 ///
 /// [`Letter`]: crate::pitch::Letter
 /// [`AccidentalSign`]: crate::pitch::AccidentalSign
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Note {
     /// The pitch (has [letter](crate::pitch::Letter) and [accidental](crate::pitch::AccidentalSign)).

--- a/src/pitch/accidental.rs
+++ b/src/pitch/accidental.rs
@@ -23,7 +23,7 @@ use crate::Semitones;
 /// let double_sharp = AccidentalSign::from_offset_semitones(Semitones(2));
 /// assert_eq!(double_sharp, AccidentalSign::DOUBLE_SHARP);
 /// ```
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AccidentalSign {
     /// The semitone offset of this accidental.

--- a/src/pitch/letter.rs
+++ b/src/pitch/letter.rs
@@ -24,7 +24,7 @@ use crate::Pitch;
 /// assert_eq!(Letter::C.offset_between(Letter::E), 2);
 /// ```
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Debug, EnumIter, FromRepr, Ord, PartialOrd)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, EnumIter, FromRepr, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Letter {
     /// C


### PR DESCRIPTION
Needed to use these types in a Hash{Map, Set}